### PR TITLE
Prestashop sometimes returns a text/html response for errors, handle …

### DIFF
--- a/Deserializers/PrestaSharpTextErrorDeserializer.cs
+++ b/Deserializers/PrestaSharpTextErrorDeserializer.cs
@@ -1,0 +1,18 @@
+using System;
+using RestSharp;
+using RestSharp.Deserializers;
+
+namespace Bukimedia.PrestaSharp.Deserializers
+{
+    public class PrestaSharpTextErrorDeserializer : IDeserializer
+    {
+        public T Deserialize<T>(IRestResponse response)
+        {
+            throw new Exception("Prestashop failed to serve XML response instead got text: " + response.Content);
+        }
+
+        public string RootElement { get; set; }
+        public string Namespace { get; set; }
+        public string DateFormat { get; set; }
+    }
+}

--- a/Factories/RestSharpFactory.cs
+++ b/Factories/RestSharpFactory.cs
@@ -1,4 +1,5 @@
-﻿using Bukimedia.PrestaSharp.Lib;
+﻿using Bukimedia.PrestaSharp.Deserializers;
+using Bukimedia.PrestaSharp.Lib;
 using RestSharp;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using RestSharp.Authenticators;
 
 namespace Bukimedia.PrestaSharp.Factories
 {
@@ -27,6 +29,7 @@ namespace Bukimedia.PrestaSharp.Factories
         protected T Execute<T>(RestRequest Request) where T : new()
         {
             var client = new RestClient();
+            client.AddHandler("text/html", new PrestaSharpTextErrorDeserializer());
             client.BaseUrl = new Uri(this.BaseUrl);
             client.Authenticator = new HttpBasicAuthenticator(this.Account, this.Password);
             Request.AddParameter("Account", this.Account, ParameterType.UrlSegment); // used on every request

--- a/PrestaSharp.csproj
+++ b/PrestaSharp.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Deserializers\PrestaSharpDeserializer.cs" />
+    <Compile Include="Deserializers\PrestaSharpTextErrorDeserializer.cs" />
     <Compile Include="Entities\address.cs" />
     <Compile Include="Entities\AuxEntities\AssociationsCustomerThread.cs" />
     <Compile Include="Entities\AuxEntities\AssociationsCombination.cs" />


### PR DESCRIPTION
…that using a new contenttype handler for restsharp.

This is the problem that is seen in issue #163 and #120

The problem can be reproduced by using this:
            OrderFactory orderFactory = new OrderFactory(BaseUrl, Account, Password);
            var orders = orderFactory.GetAll();
            orderFactory.Add(orders[0]);

Which results in the following response from prestashop:

200 OK
Content-type: text/html

Cart cannot be loaded or an order has already been placed using this cart