### PR TITLE
Implemented AddRange method to factories

### DIFF
--- a/Factories/AddressFactory.cs
+++ b/Factories/AddressFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+	    public void AddRange(List<Entities.address> Addresses)
+	    {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Addresses);
+            RestRequest request = this.RequestForAdd("addresses", Entities);
+            Execute<Entities.address>(request);
+        }
+
 		public void Update(Entities.address Address)
         {
 			RestRequest request = this.RequestForUpdate("addresses", Address.id, Address);

--- a/Factories/CarrierFactory.cs
+++ b/Factories/CarrierFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.carrier> Carriers)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Carriers);
+            RestRequest request = this.RequestForAdd("carriers", Entities);
+            Execute<Entities.carrier>(request);
+        }
+
         public void Update(Entities.carrier Carrier)
         {
             RestRequest request = this.RequestForUpdate("carriers", Carrier.id, Carrier);

--- a/Factories/CartFactory.cs
+++ b/Factories/CartFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.cart> Carts)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Carts);
+            RestRequest request = this.RequestForAdd("carts", Entities);
+            Execute<Entities.cart>(request);
+        }
+
         public void Update(Entities.cart Cart)
         {
             RestRequest request = this.RequestForUpdate("carts", Cart.id, Cart);

--- a/Factories/CategoryFactory.cs
+++ b/Factories/CategoryFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.category> Categories)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Categories);
+            RestRequest request = this.RequestForAdd("categories", Entities);
+            Execute<Entities.category>(request);
+        }
+
         public void Update(Entities.category Category)
         {
             RestRequest request = this.RequestForUpdate("categories", Category.id, Category);

--- a/Factories/CombinationFactory.cs
+++ b/Factories/CombinationFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.combination> Combinations)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Combinations);
+            RestRequest request = this.RequestForAdd("combinations", Entities);
+            Execute<Entities.combination>(request);
+        }
+
         public void Update(Entities.combination Combination)
         {
             RestRequest request = this.RequestForUpdate("combinations", Combination.id, Combination);

--- a/Factories/CountryFactory.cs
+++ b/Factories/CountryFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.country> Countries)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Countries);
+            RestRequest request = this.RequestForAdd("countries", Entities);
+            Execute<Entities.country>(request);
+        }
+
         public void Update(Entities.country Country)
         {
             RestRequest request = this.RequestForUpdate("countries", Country.id, Country);

--- a/Factories/CurrencyFactory.cs
+++ b/Factories/CurrencyFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.currency> Currencies)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Currencies);
+            RestRequest request = this.RequestForAdd("currencies", Entities);
+            Execute<Entities.currency>(request);
+        }
+
         public void Update(Entities.currency Currency)
         {
             RestRequest request = this.RequestForUpdate("currencies", Currency.id, Currency);

--- a/Factories/CustomerFactory.cs
+++ b/Factories/CustomerFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.customer> Customers)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Customers);
+            RestRequest request = this.RequestForAdd("customers", Entities);
+            Execute<Entities.customer>(request);
+        }
+
         public void Update(Entities.customer Customer)
         {
             RestRequest request = this.RequestForUpdate("customers", Customer.id, Customer);

--- a/Factories/CustomerMessageFactory.cs
+++ b/Factories/CustomerMessageFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.customer_message> CustomerMessages)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(CustomerMessages);
+            RestRequest request = this.RequestForAdd("customer_messages", Entities);
+            Execute<Entities.customer_message>(request);
+        }
+
         public void Update(Entities.customer_message CustomerMessage)
         {
             RestRequest request = this.RequestForUpdate("customer_messages", CustomerMessage.id, CustomerMessage);

--- a/Factories/CustomerThreadFactory.cs
+++ b/Factories/CustomerThreadFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.customer_thread> CustomerThreads)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(CustomerThreads);
+            RestRequest request = this.RequestForAdd("customer_threads", Entities);
+            Execute<Entities.customer_thread>(request);
+        }
+
         public void Update(Entities.customer_thread CustomerThread)
         {
             RestRequest request = this.RequestForUpdate("customer_threads", CustomerThread.id, CustomerThread);

--- a/Factories/GroupFactory.cs
+++ b/Factories/GroupFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.group> Groups)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Groups);
+            RestRequest request = this.RequestForAdd("groups", Entities);
+            Execute<Entities.group>(request);
+        }
+
         public void Update(Entities.group Group)
         {
             RestRequest request = this.RequestForUpdate("groups", Group.id, Group);

--- a/Factories/GuestFactory.cs
+++ b/Factories/GuestFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.guest> Guests)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Guests);
+            RestRequest request = this.RequestForAdd("guests", Entities);
+            Execute<Entities.guest>(request);
+        }
+
         public void Update(Entities.guest Guest)
         {
             RestRequest request = this.RequestForUpdate("guests", Guest.id, Guest);

--- a/Factories/LanguageFactory.cs
+++ b/Factories/LanguageFactory.cs
@@ -32,7 +32,15 @@ namespace Bukimedia.PrestaSharp.Factories
             Language.id = idAux;
             return this.Get((long)aux.id);
         }
-        
+
+        public void AddRange(List<Entities.language> Languages)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Languages);
+            RestRequest request = this.RequestForAdd("languages", Entities);
+            Execute<Entities.language>(request);
+        }
+
         public void Update(Entities.language Language)
         {
             RestRequest request = this.RequestForUpdate("languages", Language.id, Language);

--- a/Factories/ManufacturerFactory.cs
+++ b/Factories/ManufacturerFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.manufacturer> Manufacturers)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Manufacturers);
+            RestRequest request = this.RequestForAdd("manufacturers", Entities);
+            Execute<Entities.manufacturer>(request);
+        }
+
         public void Update(Entities.manufacturer Manufacturer)
         {
             RestRequest request = this.RequestForUpdate("manufacturers", Manufacturer.id, Manufacturer);

--- a/Factories/OrderCarrierFactory.cs
+++ b/Factories/OrderCarrierFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.order_carrier> OrderCarriers)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(OrderCarriers);
+            RestRequest request = this.RequestForAdd("order_carriers", Entities);
+            Execute<Entities.order_carrier>(request);
+        }
+
         public void Update(Entities.order_carrier OrderCarrier)
         {
             RestRequest request = this.RequestForUpdate("order_carriers", OrderCarrier.id, OrderCarrier);

--- a/Factories/OrderCartRuleFactory.cs
+++ b/Factories/OrderCartRuleFactory.cs
@@ -25,10 +25,19 @@ namespace Bukimedia.PrestaSharp.Factories
         {
             long? idAux = OrderCartRule.id; OrderCartRule.id = null;
             List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
-            Entities.Add(OrderCartRule); RestRequest request = this.RequestForAdd("order_discounts", Entities);
+            Entities.Add(OrderCartRule);
+            RestRequest request = this.RequestForAdd("order_discounts", Entities);
             Entities.order_cart_rule aux = this.Execute<Entities.order_cart_rule>(request);
             OrderCartRule.id = idAux;
             return this.Get((long)aux.id);
+        }
+
+        public void AddRange(List<Entities.order_cart_rule> OrderCartRules)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(OrderCartRules);
+            RestRequest request = this.RequestForAdd("order_discounts", Entities);
+            Execute<Entities.order_cart_rule>(request);
         }
 
         public void Update(Entities.order_cart_rule OrderCartRule)

--- a/Factories/OrderFactory.cs
+++ b/Factories/OrderFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.order> Orders)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Orders);
+            RestRequest request = this.RequestForAdd("orders", Entities);
+            Execute<Entities.order>(request);
+        }
+
         public void Update(Entities.order Order)
         {
             RestRequest request = this.RequestForUpdate("orders", Order.id, Order);

--- a/Factories/OrderHistoryFactory.cs
+++ b/Factories/OrderHistoryFactory.cs
@@ -33,6 +33,13 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.order_history> OrderHistories)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(OrderHistories);
+            RestRequest request = this.RequestForAdd("order_histories", Entities);
+            Execute<Entities.order_history>(request);
+        }
         public void Update(Entities.order_history OrderHistory)
         {
             RestRequest request = this.RequestForUpdate("order_histories", OrderHistory.id, OrderHistory);

--- a/Factories/OrderPaymentFactory.cs
+++ b/Factories/OrderPaymentFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.order_payment> OrderPayments)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(OrderPayments);
+            RestRequest request = this.RequestForAdd("order_payments", Entities);
+            Execute<Entities.order_payment>(request);
+        }
+
         public void Update(Entities.order_payment OrderPayment)
         {
             RestRequest request = this.RequestForUpdate("order_payments", OrderPayment.id, OrderPayment);

--- a/Factories/OrderStateFactory.cs
+++ b/Factories/OrderStateFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.order_state> OrderStates)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(OrderStates);
+            RestRequest request = this.RequestForAdd("order_states", Entities);
+            Execute<Entities.order_state>(request);
+        }
+
         public void Update(Entities.order_state OrderState)
         {
             RestRequest request = this.RequestForUpdate("order_states", OrderState.id, OrderState);

--- a/Factories/ProductFactory.cs
+++ b/Factories/ProductFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.product> Products)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Products);
+            RestRequest request = this.RequestForAdd("products", Entities);
+            Execute<Entities.product>(request);
+        }
+
         public void Update(Entities.product Product)
         {
             RestRequest request = this.RequestForUpdate("products", Product.id, Product);

--- a/Factories/ProductFeatureFactory.cs
+++ b/Factories/ProductFeatureFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.product_feature> ProductFeatures)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(ProductFeatures);
+            RestRequest request = this.RequestForAdd("product_features", Entities);
+            Execute<Entities.product_feature>(request);
+        }
+
         public void Update(Entities.product_feature ProductFeature)
         {
             RestRequest request = this.RequestForUpdate("product_features", ProductFeature.id, ProductFeature);

--- a/Factories/ProductFeatureValueFactory.cs
+++ b/Factories/ProductFeatureValueFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.product_feature_value> ProductFeatureValues)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(ProductFeatureValues);
+            RestRequest request = this.RequestForAdd("product_feature_values", Entities);
+            Execute<Entities.product_feature_value>(request);
+        }
+
         public void Update(Entities.product_feature_value ProductFeatureValue)
         {
             RestRequest request = this.RequestForUpdate("product_feature_values", ProductFeatureValue.id, ProductFeatureValue);

--- a/Factories/ProductOptionFactory.cs
+++ b/Factories/ProductOptionFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.product_option> ProductOptions)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(ProductOptions);
+            RestRequest request = this.RequestForAdd("product_options", Entities);
+            Execute<Entities.product_option>(request);
+        }
+
         public void Update(Entities.product_option ProductOption)
         {
             RestRequest request = this.RequestForUpdate("product_options", ProductOption.id, ProductOption);

--- a/Factories/ProductOptionValueFactory.cs
+++ b/Factories/ProductOptionValueFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.product_option_value> ProductOptionValues)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(ProductOptionValues);
+            RestRequest request = this.RequestForAdd("product_option_values", Entities);
+            Execute<Entities.product_option_value>(request);
+        }
+
         public void Update(Entities.product_option_value ProductOptionValue)
         {
             RestRequest request = this.RequestForUpdate("product_option_values", ProductOptionValue.id, ProductOptionValue);

--- a/Factories/ShopFactory.cs
+++ b/Factories/ShopFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.shop> Shops)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Shops);
+            RestRequest request = this.RequestForAdd("shops", Entities);
+            Execute<Entities.shop>(request);
+        }
+
         public void Update(Entities.shop Shop)
         {
             RestRequest request = this.RequestForUpdate("shops", Shop.id, Shop);

--- a/Factories/SpecificPriceFactory.cs
+++ b/Factories/SpecificPriceFactory.cs
@@ -33,7 +33,15 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
-		public void Update(Entities.specific_price SpecificPrice)
+        public void AddRange(List<Entities.specific_price> SpecificPrices)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(SpecificPrices);
+            RestRequest request = this.RequestForAdd("specific_prices", Entities);
+            Execute<Entities.specific_price>(request);
+        }
+
+        public void Update(Entities.specific_price SpecificPrice)
         {
 			RestRequest request = this.RequestForUpdate("specific_prices", SpecificPrice.id, SpecificPrice);
             this.Execute<Entities.specific_price>(request);

--- a/Factories/StateFactory.cs
+++ b/Factories/StateFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.state> States)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(States);
+            RestRequest request = this.RequestForAdd("states", Entities);
+            Execute<Entities.state>(request);
+        }
+
         public void Update(Entities.state State)
         {
             RestRequest request = this.RequestForUpdate("states", State.id, State);

--- a/Factories/SupplierFactory.cs
+++ b/Factories/SupplierFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.supplier> Suppliers)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Suppliers);
+            RestRequest request = this.RequestForAdd("suppliers", Entities);
+            Execute<Entities.supplier>(request);
+        }
+
         public void Update(Entities.supplier Supplier)
         {
             RestRequest request = this.RequestForUpdate("suppliers", Supplier.id, Supplier);

--- a/Factories/TagFactory.cs
+++ b/Factories/TagFactory.cs
@@ -32,7 +32,15 @@ namespace Bukimedia.PrestaSharp.Factories
             Tag.id = idAux;
             return this.Get((long)aux.id);
         }
-        
+
+        public void AddRange(List<Entities.tag> Tags)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Tags);
+            RestRequest request = this.RequestForAdd("tags", Entities);
+            Execute<Entities.tag>(request);
+        }
+
         public void Update(Entities.tag Tag)
         {
             RestRequest request = this.RequestForUpdate("tags", Tag.id, Tag);

--- a/Factories/TaxFactory.cs
+++ b/Factories/TaxFactory.cs
@@ -34,6 +34,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.tax> Taxes)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Taxes);
+            RestRequest request = this.RequestForAdd("taxes", Entities);
+            Execute<Entities.tax>(request);
+        }
+
         public void Update(Entities.tax Tax)
         {
             RestRequest request = this.RequestForUpdate("taxes", Tax.id, Tax);

--- a/Factories/TaxRuleFactory.cs
+++ b/Factories/TaxRuleFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.tax_rule> TaxRules)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(TaxRules);
+            RestRequest request = this.RequestForAdd("tax_rules", Entities);
+            Execute<Entities.tax_rule>(request);
+        }
+
         public void Update(Entities.tax_rule TaxRule)
         {
             RestRequest request = this.RequestForUpdate("tax_rules", TaxRule.id, TaxRule);

--- a/Factories/TaxRuleGroupFactory.cs
+++ b/Factories/TaxRuleGroupFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.tax_rule_group> TaxRuleGroups)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(TaxRuleGroups);
+            RestRequest request = this.RequestForAdd("tax_rule_groups", Entities);
+            Execute<Entities.tax_rule_group>(request);
+        }
+
         public void Update(Entities.tax_rule_group TaxRuleGroup)
         {
             RestRequest request = this.RequestForUpdate("tax_rule_groups", TaxRuleGroup.id, TaxRuleGroup);

--- a/Factories/ZoneFactory.cs
+++ b/Factories/ZoneFactory.cs
@@ -33,6 +33,14 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Get((long)aux.id);
         }
 
+        public void AddRange(List<Entities.zone> Zones)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.AddRange(Zones);
+            RestRequest request = this.RequestForAdd("zones", Entities);
+            Execute<Entities.zone>(request);
+        }
+
         public void Update(Entities.zone Zone)
         {
             RestRequest request = this.RequestForUpdate("zones", Zone.id, Zone);


### PR DESCRIPTION
Implemented ability to add list of entities to PrestaShop. This method
is way faster than adding entities one by one but it has some
disadvantages, for example, you can't retrieve PrestaShop's ids for
inserted entities.

I needed this for a very specific case, don't know if it would be useful for someone else, so merge if you think it will.