### PR TITLE
level_depth value for categories

### DIFF
--- a/Entities/category.cs
+++ b/Entities/category.cs
@@ -14,6 +14,7 @@ namespace Bukimedia.PrestaSharp.Entities
         public long? id { get; set; }
         public long? id_parent { get; set; }
         public long id_shop_default { get; set; }
+        public long? level_depth { get; set; }
         public long nleft { get; set; }
         public long nright { get; set; }
         /// <summary>


### PR DESCRIPTION
Needed for sorting categories list, specially if you are planning to fill a categories treeview (you can't add level 2 nodes/categories without adding before level 1 nodes/categories).