### PR TITLE
Add order_details and warehouse_product_locations support.

### DIFF
--- a/Entities/FilterEntities/order_detail.cs
+++ b/Entities/FilterEntities/order_detail.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities.FilterEntities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities/FilterEntities")]
+    public class order_detail : GenericFilterEntity
+    {
+    }
+}

--- a/Entities/FilterEntities/warehouse_product_location.cs
+++ b/Entities/FilterEntities/warehouse_product_location.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities.FilterEntities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities/FilterEntities")]
+    public class warehouse_product_location : GenericFilterEntity
+    {
+    }
+}

--- a/Entities/order_detail.cs
+++ b/Entities/order_detail.cs
@@ -1,0 +1,68 @@
+﻿using RestSharp.Serializers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities")]
+    public class order_detail : PrestaShopEntity
+    {
+        public long? id { get; set; }
+        public long? id_order { get; set; }
+        public long? product_id { get; set; }
+        public long? product_attribute_id { get; set; }
+        public int product_quantity_reinjected { get; set; }
+        public decimal group_reduction { get; set; }
+        /// <summary>
+        /// It´s a logical bool.
+        /// </summary>
+        public int discount_quantity_applied { get; set; }
+        public string download_hash { get; set; }
+        /// <summary>
+        /// It´s a logical DateTime field. Format YYYY-MM-DD HH:MM:SS.
+        /// It´s string because you can receive a string with no DateTime .Net format.
+        /// </summary>
+        public string download_deadline { get; set; }
+        public long? id_order_invoice { get; set; }
+        public long? id_warehouse { get; set; }
+        public long? id_shop { get; set; }
+        public string product_name { get; set; }
+        public int product_quantity { get; set; }
+        public int product_quantity_in_stock { get; set; }
+        public int product_quantity_return { get; set; }
+        public int product_quantity_refunded { get; set; }
+        public decimal product_price { get; set; }
+        public decimal reduction_percent { get; set; }
+        public decimal reduction_amount { get; set; }
+        public decimal reduction_amount_tax_incl { get; set; }
+        public decimal reduction_amount_tax_excl { get; set; }
+        public decimal product_quantity_discount { get; set; }
+        public string product_ean13 { get; set; }
+        public string product_upc { get; set; }
+        public string product_reference { get; set; }
+        public string product_supplier_reference { get; set; }
+        public decimal product_weight { get; set; }
+        public int tax_computation_method { get; set; }
+        public int id_tax_rules_group { get; set; }
+        public decimal ecotax { get; set; }
+        public decimal ecotax_tax_rate { get; set; }
+        public int download_nb { get; set; }
+        public decimal unit_price_tax_incl { get; set; }
+        public decimal unit_price_tax_excl { get; set; }
+        public decimal total_price_tax_incl { get; set; }
+        public decimal total_price_tax_excl { get; set; }
+        public decimal total_shipping_price_tax_excl { get; set; }
+        public decimal total_shipping_price_tax_incl { get; set; }
+        public decimal purchase_supplier_price { get; set; }
+        public decimal original_product_price { get; set; }
+        public decimal original_wholesale_price { get; set; }
+
+        public order_detail()
+        {
+        }
+    }
+}

--- a/Entities/warehouse_product_location.cs
+++ b/Entities/warehouse_product_location.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bukimedia.PrestaSharp.Entities
+{
+    public class warehouse_product_location : PrestaShopEntity
+    {
+        public long? id { get; set; }
+        public long? id_product { get; set; }
+        public long? id_product_attribute { get; set; }
+        public long id_warehouse { get; set; }
+        public string location { get; set; }
+    }
+}

--- a/Factories/OrderDetailFactory.cs
+++ b/Factories/OrderDetailFactory.cs
@@ -1,0 +1,107 @@
+﻿using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Factories
+{
+    public class OrderDetailFactory : RestSharpFactory
+    {
+        public OrderDetailFactory(string BaseUrl, string Account, string SecretKey) 
+            : base(BaseUrl, Account, SecretKey)
+        {
+        }
+
+        public Entities.order_detail Get(long OrderDetailId)
+        {
+            RestRequest request = this.RequestForGet("order_details", OrderDetailId, "order_detail");
+            return this.Execute<Entities.order_detail>(request);
+        }
+
+        public Entities.order_detail Add(Entities.order_detail OrderDetail)
+        {
+            long? idAux = OrderDetail.id; OrderDetail.id = null;
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.Add(OrderDetail); RestRequest request = this.RequestForAdd("order_details", Entities);
+            Entities.order_detail aux = this.Execute<Entities.order_detail>(request);
+            OrderDetail.id = idAux;
+            return this.Get((long)aux.id);
+        }
+
+        public void Update(Entities.order_detail OrderDetail)
+        {
+            RestRequest request = this.RequestForUpdate("order_details", OrderDetail.id, OrderDetail);
+            this.Execute<Entities.order_detail>(request);
+        }
+
+        public void Delete(long OrderDetailId)
+        {
+            RestRequest request = this.RequestForDelete("order_details", OrderDetailId);
+            this.Execute<Entities.order_detail>(request);
+        }
+
+        public void Delete(Entities.order_detail OrderDetail)
+        {
+            this.Delete((long)OrderDetail.id);
+        }
+        public List<long> GetIds()
+        {
+            RestRequest request = this.RequestForGet("order_details", null, "order_details");
+            return this.ExecuteForGetIds<List<long>>(request, "order_detail");
+        }
+
+        /// <summary>
+        /// More information about filtering: http://doc.prestashop.com/display/PS14/Chapter+8+-+Advanced+Use 
+        /// </summary> 
+        /// <param name="Filter">Example: key:name value:Apple</param> 
+        /// <param name="Sort">Field_ASC or Field_DESC. Example: name_ASC or name_DESC</param> 
+        /// <param name="Limit">Example: 5 limit to 5. 9,5 Only include the first 5 elements starting from the 10th element.</param>
+        /// <returns></returns> 
+        public List<Entities.order_detail> GetByFilter(Dictionary<string, string> Filter, string Sort, string Limit)
+        {
+            RestRequest request = this.RequestForFilter("order_details", "full", Filter, Sort, Limit, "order_details");
+            return this.ExecuteForFilter<List<Entities.order_detail>>(request);
+        }
+
+        /// <summary> 
+        /// More information about filtering: http://doc.prestashop.com/display/PS14/Chapter+8+-+Advanced+Use 
+        /// </summary> 
+        /// <param name="Filter">Example: key:name value:Apple</param> 
+        /// <param name="Sort">Field_ASC or Field_DESC. Example: name_ASC or name_DESC</param>
+        /// <param name="Limit">Example: 5 limit to 5. 9,5 Only include the first 5 elements starting from the 10th element.</param> 
+        /// <returns></returns> 
+        public List<long> GetIdsByFilter(Dictionary<string, string> Filter, string Sort, string Limit)
+        {
+            RestRequest request = this.RequestForFilter("order_details", "[id]", Filter, Sort, Limit, "order_details");
+            List<PrestaSharp.Entities.FilterEntities.order_detail> aux = this.Execute<List<PrestaSharp.Entities.FilterEntities.order_detail>>(request);
+            return (List<long>)(from t in aux select t.id).ToList<long>();
+        }
+
+        /// <summary>
+        /// Get all order_details. 
+        /// </summary> 
+        /// <returns>A list of order_details</returns> 
+        public List<Entities.order_detail> GetAll()
+        {
+            return this.GetByFilter(null, null, null);
+        }
+
+        /// <summary> 
+        /// Add a list of order_details. 
+        /// </summary> 
+        /// <param name="OrderStates"></param> 
+        /// <returns></returns> 
+        public List<Entities.order_detail> AddList(List<Entities.order_detail> OrderDetails)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            foreach (Entities.order_detail OrderDetail in OrderDetails)
+            {
+                OrderDetail.id = null; Entities.Add(OrderDetail);
+            }
+            RestRequest request = this.RequestForAdd("order_details", Entities); return this.Execute<List<Entities.order_detail>>(request);
+        }
+    }
+}

--- a/Factories/WarehouseProductLocationFactory.cs
+++ b/Factories/WarehouseProductLocationFactory.cs
@@ -1,0 +1,106 @@
+﻿using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bukimedia.PrestaSharp.Factories
+{
+    public class WarehouseProductLocationFactory : RestSharpFactory
+    {
+        public WarehouseProductLocationFactory(string BaseUrl, string Account, string SecretKey)
+            : base(BaseUrl, Account, SecretKey)
+        {
+        }
+
+        public Entities.warehouse_product_location Get(long WarehouseProductLocationId)
+        {
+            RestRequest request = this.RequestForGet("warehouse_product_locations", WarehouseProductLocationId, "warehouse_product_location");
+            return this.Execute<Entities.warehouse_product_location>(request);
+        }
+
+        public Entities.warehouse_product_location Add(Entities.warehouse_product_location WarehouseProductLocation)
+        {
+            long? idAux = WarehouseProductLocation.id; WarehouseProductLocation.id = null;
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            Entities.Add(WarehouseProductLocation); RestRequest request = this.RequestForAdd("warehouse_product_locations", Entities);
+            Entities.warehouse_product_location aux = this.Execute<Entities.warehouse_product_location>(request);
+            WarehouseProductLocation.id = idAux;
+            return this.Get((long)aux.id);
+        }
+
+        public void Update(Entities.warehouse_product_location WarehouseProductLocation)
+        {
+            RestRequest request = this.RequestForUpdate("warehouse_product_locations", WarehouseProductLocation.id, WarehouseProductLocation);
+            this.Execute<Entities.warehouse_product_location>(request);
+        }
+
+        public void Delete(long WarehouseProductLocation)
+        {
+            RestRequest request = this.RequestForDelete("warehouse_product_locations", WarehouseProductLocation);
+            this.Execute<Entities.warehouse_product_location>(request);
+        }
+
+        public void Delete(Entities.warehouse_product_location WarehouseProductLocation)
+        {
+            this.Delete((long)WarehouseProductLocation.id);
+        }
+        public List<long> GetIds()
+        {
+            RestRequest request = this.RequestForGet("warehouse_product_locations", null, "warehouse_product_locations");
+            return this.ExecuteForGetIds<List<long>>(request, "warehouse_product_location");
+        }
+
+        /// <summary>
+        /// More information about filtering: http://doc.prestashop.com/display/PS14/Chapter+8+-+Advanced+Use 
+        /// </summary> 
+        /// <param name="Filter">Example: key:name value:Apple</param> 
+        /// <param name="Sort">Field_ASC or Field_DESC. Example: name_ASC or name_DESC</param> 
+        /// <param name="Limit">Example: 5 limit to 5. 9,5 Only include the first 5 elements starting from the 10th element.</param>
+        /// <returns></returns> 
+        public List<Entities.warehouse_product_location> GetByFilter(Dictionary<string, string> Filter, string Sort, string Limit)
+        {
+            RestRequest request = this.RequestForFilter("warehouse_product_locations", "full", Filter, Sort, Limit, "warehouse_product_locations");
+            return this.ExecuteForFilter<List<Entities.warehouse_product_location>>(request);
+        }
+
+        /// <summary> 
+        /// More information about filtering: http://doc.prestashop.com/display/PS14/Chapter+8+-+Advanced+Use 
+        /// </summary> 
+        /// <param name="Filter">Example: key:name value:Apple</param> 
+        /// <param name="Sort">Field_ASC or Field_DESC. Example: name_ASC or name_DESC</param>
+        /// <param name="Limit">Example: 5 limit to 5. 9,5 Only include the first 5 elements starting from the 10th element.</param> 
+        /// <returns></returns> 
+        public List<long> GetIdsByFilter(Dictionary<string, string> Filter, string Sort, string Limit)
+        {
+            RestRequest request = this.RequestForFilter("warehouse_product_locations", "[id]", Filter, Sort, Limit, "warehouse_product_locations");
+            List<PrestaSharp.Entities.FilterEntities.warehouse_product_location> aux = this.Execute<List<PrestaSharp.Entities.FilterEntities.warehouse_product_location>>(request);
+            return (List<long>)(from t in aux select t.id).ToList<long>();
+        }
+
+        /// <summary>
+        /// Get all warehouse_product_locations. 
+        /// </summary> 
+        /// <returns>A list of order_details</returns> 
+        public List<Entities.warehouse_product_location> GetAll()
+        {
+            return this.GetByFilter(null, null, null);
+        }
+
+        /// <summary> 
+        /// Add a list of warehouse_product_locations. 
+        /// </summary> 
+        /// <param name="OrderStates"></param> 
+        /// <returns></returns> 
+        public List<Entities.warehouse_product_location> AddList(List<Entities.warehouse_product_location> WarehouseProductLocations)
+        {
+            List<PrestaSharp.Entities.PrestaShopEntity> Entities = new List<PrestaSharp.Entities.PrestaShopEntity>();
+            foreach (Entities.warehouse_product_location OrderDetail in WarehouseProductLocations)
+            {
+                OrderDetail.id = null; Entities.Add(OrderDetail);
+            }
+            RestRequest request = this.RequestForAdd("warehouse_product_locations", Entities); return this.Execute<List<Entities.warehouse_product_location>>(request);
+        }
+    }
+}

--- a/PrestaSharp.csproj
+++ b/PrestaSharp.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Entities\FilterEntities\customer_message.cs" />
     <Compile Include="Entities\FilterEntities\order_carrier.cs" />
     <Compile Include="Entities\FilterEntities\order_cart_rule.cs" />
+    <Compile Include="Entities\FilterEntities\order_detail.cs" />
     <Compile Include="Entities\FilterEntities\order_history.cs" />
     <Compile Include="Entities\FilterEntities\order_payment.cs" />
     <Compile Include="Entities\FilterEntities\product_supplier.cs" />
@@ -93,6 +94,7 @@
     <Compile Include="Entities\order_carrier.cs" />
     <Compile Include="Entities\FilterEntities\state.cs" />
     <Compile Include="Entities\order_cart_rule.cs" />
+    <Compile Include="Entities\order_detail.cs" />
     <Compile Include="Entities\order_history.cs" />
     <Compile Include="Entities\order_payment.cs" />
     <Compile Include="Entities\product_supplier.cs" />
@@ -170,6 +172,7 @@
     <Compile Include="Factories\CustomerMessageFactory.cs" />
     <Compile Include="Factories\OrderCarrierFactory.cs" />
     <Compile Include="Factories\OrderCartRuleFactory.cs" />
+    <Compile Include="Factories\OrderDetailFactory.cs" />
     <Compile Include="Factories\OrderHistoryFactory.cs" />
     <Compile Include="Factories\OrderPaymentFactory.cs" />
     <Compile Include="Factories\ProductSupplierFactory.cs" />

--- a/PrestaSharp.csproj
+++ b/PrestaSharp.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Entities\FilterEntities\specific_price_rule.cs" />
     <Compile Include="Entities\FilterEntities\tax.cs" />
     <Compile Include="Entities\FilterEntities\tax_rule.cs" />
+    <Compile Include="Entities\FilterEntities\warehouse_product_location.cs" />
     <Compile Include="Entities\order_carrier.cs" />
     <Compile Include="Entities\FilterEntities\state.cs" />
     <Compile Include="Entities\order_cart_rule.cs" />
@@ -104,6 +105,7 @@
     <Compile Include="Entities\tax.cs" />
     <Compile Include="Entities\tax_rule.cs" />
     <Compile Include="Entities\warehouse.cs" />
+    <Compile Include="Entities\warehouse_product_location.cs" />
     <Compile Include="Entities\zone.cs" />
     <Compile Include="Entities\FilterEntities\guest.cs" />
     <Compile Include="Entities\guest.cs" />
@@ -181,6 +183,7 @@
     <Compile Include="Factories\TaxFactory.cs" />
     <Compile Include="Factories\TaxRuleFactory.cs" />
     <Compile Include="Factories\WarehouseFactory.cs" />
+    <Compile Include="Factories\WarehouseProductLocationFactory.cs" />
     <Compile Include="Factories\ZoneFactory.cs" />
     <Compile Include="Factories\GuestFactory.cs" />
     <Compile Include="Factories\TaxRuleGroupFactory.cs" />


### PR DESCRIPTION
Add support for grabbing order_details and warehouse_product_locations, comes in useful when you are using the advanced stock management system/warehouses from Prestashop 1.6 and earlier.

As the ASM/warehouse system was removed from 1.7 (and is being re added) not sure how useful the warehouse_product_locations part of this pull request is, but order_details should still work and provide more information that is not part of the order_rows association.