### PR TITLE
Generate NuGet package

### DIFF
--- a/PrestaSharp.csproj
+++ b/PrestaSharp.csproj
@@ -6,8 +6,16 @@
     <Company>Bukimedia</Company>
     <Authors>Bukimedia</Authors>
     <Product>PrestaSharp</Product>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>prestashop rest webservice</PackageTags>
+    <PackageReleaseNotes>Compatibility with Prestashop 1.7</PackageReleaseNotes>
+    <Copyright>Copyright (C) 2016 Bukimedia</Copyright>
+    <RepositoryType>Dependency</RepositoryType>
+    <PackageProjectUrl>https://github.com/Bukimedia/PrestaSharp</PackageProjectUrl>
+    <PackageIconUrl>https://avatars0.githubusercontent.com/u/5653635?s=200&amp;amp;v=4</PackageIconUrl>
+    <RepositoryUrl>https://github.com/Bukimedia/PrestaSharp</RepositoryUrl>
+    <Description>CSharp .Net client library for the PrestaShop API via web service</Description>
+    <PackageLicenseUrl>https://www.gnu.org/licenses/gpl-3.0.en.html</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.2.2" />


### PR DESCRIPTION
It fills the assembly information for generating a .nupkg in the bin directory on each build.

I think it will be a good step to make, to include this original repo of Prestasharp under the NuGet repository, so if you accept the pull request, the next actions to do would be:

* Create a 1.0.0 tag.
* Upload the .nupkg to NuGet public repository: https://docs.microsoft.com/es-es/nuget/create-packages/publish-a-package

If you agree with that and you think I could help, please let me know.