### PR TITLE
Add .NET Standard 2.0 as target framework and update RestSharp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,9 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 /.vs
+
+#############
+## Rider
+#############
+
+.idea/

--- a/PrestaSharp.csproj
+++ b/PrestaSharp.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <RootNamespace>Bukimedia.PrestaSharp</RootNamespace>
     <AssemblyName>Bukimedia.PrestaSharp</AssemblyName>
     <Company>Bukimedia</Company>
@@ -20,7 +20,7 @@
     <Version>1.0.1-SNAPSHOT</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.2.2" />
+    <PackageReference Include="RestSharp" Version="106.6.9" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.2.3" targetFramework="net45" />
+  <package id="RestSharp" version="106.6.9" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Adding .NET Standard as a target framework allows PrestaSharp to be user in any platform and OS.