### PR TITLE
Fix error adding first product_feature (when no product feature exists)

### DIFF
--- a/PrestaSharp/Deserializers/PrestaSharpDeserializer.cs
+++ b/PrestaSharp/Deserializers/PrestaSharpDeserializer.cs
@@ -129,7 +129,8 @@ namespace Bukimedia.PrestaSharp.Deserializers
                 }
                 else if (type.IsPrimitive)
                 {
-                    prop.SetValue(x, value.ChangeType(type, Culture), null);
+                    if (!String.IsNullOrEmpty(value.ToString()))
+                        prop.SetValue(x, value.ChangeType(type, Culture), null);
                 }
                 else if (type.IsEnum)
                 {

--- a/README.md
+++ b/README.md
@@ -45,24 +45,10 @@ ManufacturerFactory.Delete(Manufacturer);
 3) Add an image:
 
 ```
-Bukimedia.PrestaSharp.Entities.product MyProduct = new Bukimedia.PrestaSharp.Entities.product();
-ProductFactory ProductFactory = new ProductFactory(BaseUrl, Account, Password);
-MyProduct = ProductFactory.Add(MyProduct);
-ImageFactory ImageFactory = new ImageFactory(BaseUrl, Account, Password);
+Bukimedia.PrestaSharp.Entities.product MyProduct = new Bukimedia.PrestaSharp.Entities.product()
+MyProduct = ProductFactory.Add(MyProduct)
 ImageFactory.AddProductImage((long)MyProduct.id, "C:\\MyImage.jpg");
 ```
-
-4) Set quantity of products:
-
-```
-StockAvailableFactory StockAvailableFactory = new StockAvailableFactory(BaseUrl, Account, Password);
-long stockAvailableId = product.associations.stock_availables[0].id;
-Bukimedia.PrestaSharp.Entities.stock_available MyStockAvailable = StockAvailableFactory.Get(stockAvailableId);
-MyStockAvailable.quantity = 99;	// Number of available products
-MyStockAvailable.out_of_stock = 1; // Must enable orders
-StockAvailableFactory.Update(MyStockAvailable);
-```
-
 
 ## Advanced usage
 1) Get all. This sample retrieves the list of manufacturers:

--- a/README.md
+++ b/README.md
@@ -45,10 +45,23 @@ ManufacturerFactory.Delete(Manufacturer);
 3) Add an image:
 
 ```
-Bukimedia.PrestaSharp.Entities.product MyProduct = new Bukimedia.PrestaSharp.Entities.product()
-MyProduct = ProductFactory.Add(MyProduct)
+Bukimedia.PrestaSharp.Entities.product MyProduct = new Bukimedia.PrestaSharp.Entities.product();
+ProductFactory ProductFactory = new ProductFactory(BaseUrl, Account, Password);
+MyProduct = ProductFactory.Add(MyProduct);
+ImageFactory ImageFactory = new ImageFactory(BaseUrl, Account, Password);
 ImageFactory.AddProductImage((long)MyProduct.id, "C:\\MyImage.jpg");
 ```
+
+4) Set quantity of products:
+
+```
+StockAvailableFactory StockAvailableFactory = new StockAvailableFactory(BaseUrl, Account, Password);
+long stockAvailableId = product.associations.stock_availables[0].id;
+Bukimedia.PrestaSharp.Entities.stock_available MyStockAvailable = StockAvailableFactory.Get(stockAvailableId);
+MyStockAvailable.quantity = 99;	// Number of available products
+MyStockAvailable.out_of_stock = 1; // Must enable orders
+StockAvailableFactory.Update(MyStockAvailable);
+
 
 ## Advanced usage
 1) Get all. This sample retrieves the list of manufacturers:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Bukimedia.PrestaSharp.Entities.stock_available MyStockAvailable = StockAvailable
 MyStockAvailable.quantity = 99;	// Number of available products
 MyStockAvailable.out_of_stock = 1; // Must enable orders
 StockAvailableFactory.Update(MyStockAvailable);
+```
 
 
 ## Advanced usage


### PR DESCRIPTION
When creating the first product_feature in the database, the response from PrestaShop API is OK, but contains an empty "position" element:
`<position></position>`

This raises "object null reference error" in PrestaSharpDeserializer, because "position" element is expected to contain any non-empty INT value.
The error does not appear when creating 2nd, 3rd, etc. product_feature.