### PR TITLE
Fixing deserialization leading to null pointer

### DIFF
--- a/PrestaSharp.IntegrationTests/BaseTest.cs
+++ b/PrestaSharp.IntegrationTests/BaseTest.cs
@@ -2,7 +2,7 @@ namespace PrestaSharp.IntegrationTests
 {
     public class BaseTest
     {
-        protected const string TestUrl = "http://prestashop.local/api";
-        protected const string TestApiKey = "GLPLF5YF3S3UW9X7U4EWCP5ABXQUJ6PW";
+        protected const string TestUrl = "http://localhost:81/prestashop/api";
+        protected const string TestApiKey = "N7ZF5UEB1BIPETB68ZJ2AT1SLLTXCVUP";
     }
 }

--- a/PrestaSharp.IntegrationTests/BaseTest.cs
+++ b/PrestaSharp.IntegrationTests/BaseTest.cs
@@ -2,7 +2,7 @@ namespace PrestaSharp.IntegrationTests
 {
     public class BaseTest
     {
-        protected const string TestUrl = "http://localhost:8080/api";
-        protected const string TestApiKey = "F9HRC3MTYYSLC98C57HCHRHAHPRFINMB";
+        protected const string TestUrl = "http://prestashop.local/api";
+        protected const string TestApiKey = "GLPLF5YF3S3UW9X7U4EWCP5ABXQUJ6PW";
     }
 }

--- a/PrestaSharp.IntegrationTests/DeliveryTests.cs
+++ b/PrestaSharp.IntegrationTests/DeliveryTests.cs
@@ -1,0 +1,26 @@
+using Bukimedia.PrestaSharp.Factories;
+using NUnit.Framework;
+
+namespace PrestaSharp.IntegrationTests
+{
+    public class DeliveryTests : BaseTest
+    {
+
+        private DeliveryFactory factory;
+
+        [SetUp]
+        public void Setup()
+        {
+            factory = new DeliveryFactory(TestUrl, TestApiKey, null);
+        }
+
+        [Test]
+        public void Listing()
+        {
+            var delvieries = factory.GetAll();
+
+            Assert.IsNotNull(delvieries);
+            Assert.AreEqual(4, delvieries.Count);
+        }
+    }
+}

--- a/PrestaSharp.IntegrationTests/PriceRangeTests.cs
+++ b/PrestaSharp.IntegrationTests/PriceRangeTests.cs
@@ -1,0 +1,26 @@
+using Bukimedia.PrestaSharp.Factories;
+using NUnit.Framework;
+
+namespace PrestaSharp.IntegrationTests
+{
+    public class PriceRangeTests : BaseTest
+    {
+
+        private PriceRangeFactory factory;
+
+        [SetUp]
+        public void Setup()
+        {
+            factory = new PriceRangeFactory(TestUrl, TestApiKey, null);
+        }
+
+        [Test]
+        public void Listing()
+        {
+            var priceRanges = factory.GetAll();
+
+            Assert.IsNotNull(priceRanges);
+            Assert.AreEqual(1, priceRanges.Count);
+        }
+    }
+}

--- a/PrestaSharp.IntegrationTests/WeightRangeTests.cs
+++ b/PrestaSharp.IntegrationTests/WeightRangeTests.cs
@@ -1,0 +1,26 @@
+using Bukimedia.PrestaSharp.Factories;
+using NUnit.Framework;
+
+namespace PrestaSharp.IntegrationTests
+{
+    public class WeightRangeTests : BaseTest
+    {
+
+        private WeightRangeFactory factory;
+
+        [SetUp]
+        public void Setup()
+        {
+            factory = new WeightRangeFactory(TestUrl, TestApiKey, null);
+        }
+
+        [Test]
+        public void Listing()
+        {
+            var weightRanges = factory.GetAll();
+
+            Assert.IsNotNull(weightRanges);
+            Assert.AreEqual(1, weightRanges.Count);
+        }
+    }
+}

--- a/PrestaSharp.sln
+++ b/PrestaSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.106
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29609.76
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrestaSharp", "PrestaSharp\PrestaSharp.csproj", "{6AAC9477-CD24-49CA-930C-DB44A7FCE87D}"
 EndProject
@@ -10,10 +10,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5A96B1D9-38AE-4E49-A79D-95D92DCF78A6}"
 	ProjectSection(SolutionItems) = preProject
 		.travis.yml = .travis.yml
-		README.md = README.md
-		LICENSE = LICENSE
 		docker-compose.yml = docker-compose.yml
+		LICENSE = LICENSE
+		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrestaSharpTests", "PrestaSharpTests\PrestaSharpTests.csproj", "{8A1A5884-5BCE-4329-8E5D-723AB22D07C6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,6 +31,10 @@ Global
 		{7F2878D9-7936-4076-A195-3BF93BA7A851}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F2878D9-7936-4076-A195-3BF93BA7A851}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F2878D9-7936-4076-A195-3BF93BA7A851}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A1A5884-5BCE-4329-8E5D-723AB22D07C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A1A5884-5BCE-4329-8E5D-723AB22D07C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A1A5884-5BCE-4329-8E5D-723AB22D07C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A1A5884-5BCE-4329-8E5D-723AB22D07C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PrestaSharp/Deserializers/PrestaSharpDeserializer.cs
+++ b/PrestaSharp/Deserializers/PrestaSharpDeserializer.cs
@@ -1,22 +1,21 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Xml.Linq;
-using RestSharp.Extensions;
-using System.Globalization;
 using System.Xml;
-using System.ComponentModel;
-using RestSharp.Deserializers;
+using System.Xml.Linq;
 using RestSharp;
-using RestSharp.Serialization;
+using RestSharp.Extensions;
 using RestSharp.Serialization.Xml;
 
 namespace Bukimedia.PrestaSharp.Deserializers
 {
     public class PrestaSharpDeserializer : IXmlDeserializer
     {
+        //RootElement comes from RestSharp. It's value is taken from Request.RootElement
         public string RootElement { get; set; }
         public string Namespace { get; set; }
         public string DateFormat { get; set; }
@@ -32,12 +31,23 @@ namespace Bukimedia.PrestaSharp.Deserializers
             if (string.IsNullOrEmpty(response.Content))
                 return default(T);
 
-            var doc = XDocument.Parse(response.Content);
-            var root = doc.Root;
-            if (RootElement.HasValue() && doc.Root != null)
+            XDocument doc = XDocument.Parse(response.Content);
+            XElement root;
+
+            var objType = typeof(T);
+            XElement firstChild = doc.Root.Descendants().FirstOrDefault();
+
+            if (doc.Root == null || firstChild?.Name == null)
             {
-                root = doc.Root.Element(RootElement.AsNamespaced(Namespace));
+                string finalResponseError = "Deserialization problem. Root is null or response has no child.";
+                if (!string.IsNullOrWhiteSpace(response.ErrorMessage))
+                {
+                    finalResponseError += $" Additionnal information is: {response.ErrorMessage}";
+                }
+                throw new PrestaSharpException(response.Content, finalResponseError, response.StatusCode, response.ErrorException);
             }
+
+            root = doc.Root.Element(firstChild.Name.ToString().AsNamespaced(Namespace));
 
             // autodetect xml namespace
             if (!Namespace.HasValue())
@@ -46,9 +56,9 @@ namespace Bukimedia.PrestaSharp.Deserializers
             }
 
             var x = Activator.CreateInstance<T>();
-            var objType = x.GetType();
+            bool isSubclassOfRawGeneric = objType.IsSubclassOfRawGeneric(typeof(List<>));
 
-            if (objType.IsSubclassOfRawGeneric(typeof(List<>)))
+            if (isSubclassOfRawGeneric)
             {
                 x = (T)HandleListDerivative(x, root, objType.Name, objType);
             }

--- a/PrestaSharp/Deserializers/PrestaSharpDeserializer.cs
+++ b/PrestaSharp/Deserializers/PrestaSharpDeserializer.cs
@@ -140,7 +140,9 @@ namespace Bukimedia.PrestaSharp.Deserializers
                 else if (type.IsPrimitive)
                 {
                     if (!String.IsNullOrEmpty(value.ToString()))
-                        prop.SetValue(x, value.ChangeType(type, Culture), null);
+                    {
+                        prop.SetValue(x, System.Convert.ChangeType(value, type, Culture), null);
+                    }
                 }
                 else if (type.IsEnum)
                 {
@@ -369,7 +371,7 @@ namespace Bukimedia.PrestaSharp.Deserializers
             }
             else if (t.IsPrimitive)
             {
-                item = element.Value.ChangeType(t, Culture);
+                item = System.Convert.ChangeType(element.Value, t, Culture);
             }
             else
             {

--- a/PrestaSharp/Deserializers/PrestaSharpDeserializer.cs
+++ b/PrestaSharp/Deserializers/PrestaSharpDeserializer.cs
@@ -85,7 +85,7 @@ namespace Bukimedia.PrestaSharp.Deserializers
             }
         }
 
-        protected virtual void Map(object x, XElement root)
+        public virtual void Map(object x, XElement root)
         {
             var objType = x.GetType();
             var props = objType.GetProperties();

--- a/PrestaSharp/Entities/delivery.cs
+++ b/PrestaSharp/Entities/delivery.cs
@@ -7,8 +7,8 @@ namespace Bukimedia.PrestaSharp.Entities
     {
         public long? id { get; set; }
         public long id_carrier { get; set; }
-        public int id_range_price { get; set; }
-        public int id_range_weight { get; set; }
+        public long id_range_price { get; set; }
+        public long id_range_weight { get; set; }
         public long? id_zone { get; set; }
         public long? id_shop { get; set; }
         public long? id_shop_group { get; set; }

--- a/PrestaSharp/Entities/delivery.cs
+++ b/PrestaSharp/Entities/delivery.cs
@@ -1,0 +1,20 @@
+﻿using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities")]
+    public class delivery : PrestaShopEntity, IPrestaShopFactoryEntity
+    {
+        public long? id { get; set; }
+        public long id_carrier { get; set; }
+        public int id_range_price { get; set; }
+        public int id_range_weight { get; set; }
+        public long? id_shop { get; set; }
+        public long? id_shop_group { get; set; }
+        public decimal price { get; set; }
+
+        public delivery()
+        {
+        }
+    }
+}

--- a/PrestaSharp/Entities/delivery.cs
+++ b/PrestaSharp/Entities/delivery.cs
@@ -9,6 +9,7 @@ namespace Bukimedia.PrestaSharp.Entities
         public long id_carrier { get; set; }
         public int id_range_price { get; set; }
         public int id_range_weight { get; set; }
+        public long? id_zone { get; set; }
         public long? id_shop { get; set; }
         public long? id_shop_group { get; set; }
         public decimal price { get; set; }

--- a/PrestaSharp/Entities/price_range.cs
+++ b/PrestaSharp/Entities/price_range.cs
@@ -1,0 +1,14 @@
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities")]
+    public class price_range : PrestaShopEntity, IPrestaShopFactoryEntity
+    {
+        public long? id { get; set; }
+        public long? id_carrier { get; set; }
+        public float delimiter1 { get; set; }
+        public float delimiter2 { get; set; }
+        public price_range() { }
+    }
+}

--- a/PrestaSharp/Entities/weight_range.cs
+++ b/PrestaSharp/Entities/weight_range.cs
@@ -1,0 +1,14 @@
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities")]
+    public class weight_range : PrestaShopEntity, IPrestaShopFactoryEntity
+    {
+        public long? id { get; set; }
+        public long? id_carrier { get; set; }
+        public float delimiter1 { get; set; }
+        public float delimiter2 { get; set; }
+        public weight_range() { }
+    }
+}

--- a/PrestaSharp/Factories/DeliveryFactory.cs
+++ b/PrestaSharp/Factories/DeliveryFactory.cs
@@ -1,0 +1,15 @@
+﻿using Bukimedia.PrestaSharp.Entities;
+
+namespace Bukimedia.PrestaSharp.Factories
+{
+    public class DeliveryFactory : GenericFactory<delivery>
+    {
+        protected override string singularEntityName { get { return "delivery"; } }
+        protected override string pluralEntityName { get { return "deliveries"; } }
+
+        public DeliveryFactory(string BaseUrl, string Account, string SecretKey)
+            : base(BaseUrl, Account, SecretKey)
+        {
+        }
+    }
+}

--- a/PrestaSharp/Factories/PriceRangeFactory.cs
+++ b/PrestaSharp/Factories/PriceRangeFactory.cs
@@ -1,0 +1,15 @@
+using Bukimedia.PrestaSharp.Entities;
+
+namespace Bukimedia.PrestaSharp.Factories
+{
+    public class PriceRangeFactory : GenericFactory<price_range>
+    {
+        protected override string singularEntityName { get { return "price_range"; } }
+        protected override string pluralEntityName { get { return "price_ranges"; } }
+
+        public PriceRangeFactory(string BaseUrl, string Account, string SecretKey)
+            : base(BaseUrl, Account, SecretKey)
+        {
+        }
+    }
+}

--- a/PrestaSharp/Factories/WeightRangeFactory.cs
+++ b/PrestaSharp/Factories/WeightRangeFactory.cs
@@ -1,0 +1,15 @@
+using Bukimedia.PrestaSharp.Entities;
+
+namespace Bukimedia.PrestaSharp.Factories
+{
+    public class WeightRangeFactory : GenericFactory<weight_range>
+    {
+        protected override string singularEntityName { get { return "weight_range"; } }
+        protected override string pluralEntityName { get { return "weight_ranges"; } }
+
+        public WeightRangeFactory(string BaseUrl, string Account, string SecretKey)
+            : base(BaseUrl, Account, SecretKey)
+        {
+        }
+    }
+}

--- a/PrestaSharp/PrestaSharp.csproj
+++ b/PrestaSharp/PrestaSharp.csproj
@@ -22,7 +22,7 @@
     <PackageVersion>1.2.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.6.10" />
+    <PackageReference Include="RestSharp" Version="106.11.4" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/PrestaSharp/PrestaSharp.csproj
+++ b/PrestaSharp/PrestaSharp.csproj
@@ -4,22 +4,22 @@
     <RootNamespace>Bukimedia.PrestaSharp</RootNamespace>
     <AssemblyName>Bukimedia.PrestaSharp</AssemblyName>
     <Company>Bukimedia</Company>
-    <Authors>Bukimedia</Authors>
-    <Product>PrestaSharp</Product>
+    <Authors>Bukimedia, oromand</Authors>
+    <Product>PrestaSharp.Extended</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>prestashop rest webservice official prestasharp bukimedia</PackageTags>
-    <PackageReleaseNotes>* Added Task/Async features.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed deserialization problems</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 Bukimedia</Copyright>
     <RepositoryType>Dependency</RepositoryType>
-    <PackageProjectUrl>http://bukimedia.github.io/PrestaSharp/</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/oromand/PrestaSharp/</PackageProjectUrl>
     <PackageIconUrl>https://avatars0.githubusercontent.com/u/5653635?s=200&amp;amp;v=4</PackageIconUrl>
-    <RepositoryUrl>https://github.com/Bukimedia/PrestaSharp</RepositoryUrl>
+    <projectUrl>https://github.com/oromand/PrestaSharp/</projectUrl>
     <Description>CSharp .Net client library for the PrestaShop API via web service</Description>
     <PackageLicenseUrl>https://www.gnu.org/licenses/gpl-3.0.en.html</PackageLicenseUrl>
-    <PackageId>PrestaSharp</PackageId>
-    <Version>1.0.5.1-SNAPSHOT</Version>
-    <Title>Bukimedia PrestaSharp</Title>
-    <PackageVersion>1.1.0.1-SNAPSHOT</PackageVersion>
+    <PackageId>PrestaSharp.Extended</PackageId>
+    <Version>1.2.0</Version>
+    <Title>Bukimedia PrestaSharp - Extended</Title>
+    <PackageVersion>1.2.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.6.10" />

--- a/PrestaSharp/PrestaSharp.csproj
+++ b/PrestaSharp/PrestaSharp.csproj
@@ -8,7 +8,7 @@
     <Product>PrestaSharp.Extended</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>prestashop rest webservice official prestasharp</PackageTags>
-    <PackageReleaseNotes>Fixed deserialization problems</PackageReleaseNotes>
+    <PackageReleaseNotes>Added deliveries, price_ranges and weight_ranges implementation</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 Bukimedia</Copyright>
     <RepositoryType>Dependency</RepositoryType>
     <PackageProjectUrl>https://github.com/oromand/PrestaSharp/</PackageProjectUrl>
@@ -19,7 +19,7 @@
     <PackageId>PrestaSharp.Extended</PackageId>
     <Version>1.2.0</Version>
     <Title>Bukimedia PrestaSharp - Extended</Title>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.2.3</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.11.4" />

--- a/PrestaSharp/PrestaSharp.csproj
+++ b/PrestaSharp/PrestaSharp.csproj
@@ -7,14 +7,14 @@
     <Authors>Bukimedia, oromand</Authors>
     <Product>PrestaSharp.Extended</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageTags>prestashop rest webservice official prestasharp bukimedia</PackageTags>
+    <PackageTags>prestashop rest webservice official prestasharp</PackageTags>
     <PackageReleaseNotes>Fixed deserialization problems</PackageReleaseNotes>
     <Copyright>Copyright (C) 2019 Bukimedia</Copyright>
     <RepositoryType>Dependency</RepositoryType>
     <PackageProjectUrl>https://github.com/oromand/PrestaSharp/</PackageProjectUrl>
     <PackageIconUrl>https://avatars0.githubusercontent.com/u/5653635?s=200&amp;amp;v=4</PackageIconUrl>
     <projectUrl>https://github.com/oromand/PrestaSharp/</projectUrl>
-    <Description>CSharp .Net client library for the PrestaShop API via web service</Description>
+    <Description>Fork from the official Prestasharp Nuget. Attempting to fix the stability issues.</Description>
     <PackageLicenseUrl>https://www.gnu.org/licenses/gpl-3.0.en.html</PackageLicenseUrl>
     <PackageId>PrestaSharp.Extended</PackageId>
     <Version>1.2.0</Version>

--- a/PrestaSharpTests/Deserializers/PrestaSharpDeserializerTests.cs
+++ b/PrestaSharpTests/Deserializers/PrestaSharpDeserializerTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bukimedia.PrestaSharp.Deserializers.Tests
+{
+
+    class FakeObject
+    {
+        public string StringProperty { get; set; }
+        public int IntProperty { get; set; }
+        public decimal DecimalProperty { get; set; }
+    }
+
+    [TestClass()]
+    public class PrestaSharpDeserializerTests
+    {
+        [TestMethod()]
+        public void MapTest()
+        {
+            PrestaSharpDeserializer instanceUnderTest = new PrestaSharpDeserializer();
+            string fileContent = System.IO.File.ReadAllText("FakeObject.xml");
+            System.Xml.Linq.XDocument xmlDocument = XDocument.Parse(fileContent);
+            var rootElement = xmlDocument.Root.Descendants().FirstOrDefault();
+
+            FakeObject objectToMap = Activator.CreateInstance<FakeObject>();
+
+            instanceUnderTest.Map(objectToMap, rootElement);
+
+            Assert.IsTrue(objectToMap.StringProperty == "This is my value");
+            Assert.IsTrue(objectToMap.IntProperty == 42);
+            Assert.IsTrue(objectToMap.DecimalProperty == 1.2m);
+        }
+    }
+}

--- a/PrestaSharpTests/FakeObject.xml
+++ b/PrestaSharpTests/FakeObject.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<prestashop xmlns:xlink="http://www.w3.org/1999/xlink">
+  <fake_object>
+    <id><![CDATA[62]]></id>
+    <string_property xlink:href="http://prestashop.local/api/products/20"><![CDATA[This is my value]]></string_property>
+    <int_property xlink:href="http://prestashop.local/api/combinations/42"><![CDATA[42]]></int_property>
+    <decimal_property xlink:href="http://prestashop.local/api/shops/1"><![CDATA[1.2]]></decimal_property>
+  </fake_object>
+</prestashop>

--- a/PrestaSharpTests/PrestaSharpTests.csproj
+++ b/PrestaSharpTests/PrestaSharpTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="FakeObject.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="FakeObject.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PrestaSharp\PrestaSharp.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This is a PR fixing a deserialization issue causing a null pointer exception. 
In particular, the attribute RootElement is set by the caller and was leading to a null value during the mapping phase. RootElement is marked by RestSharp as obsolete.
