### PR TITLE
Add head functionality in Generic Factory and Image Factory

### DIFF
--- a/PrestaSharp/Factories/GenericFactory.cs
+++ b/PrestaSharp/Factories/GenericFactory.cs
@@ -23,6 +23,17 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Execute<T>(request);
         }
 
+        /// <summary>
+        /// Checks if the id exists and return true or false
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public bool Check(long id)
+        {
+            RestRequest request = this.RequestForHead(pluralEntityName, id);
+            return this.ExecuteHead(request);
+        }
+
         public T Add(T Entity)
         {
             long? idAux = Entity.id;
@@ -146,11 +157,16 @@ namespace Bukimedia.PrestaSharp.Factories
             return this.Execute<List<T>>(request);
         }
 
-
         public async Task<T> GetAsync(long id)
         {
             RestRequest request = this.RequestForGet(pluralEntityName, id, singularEntityName);
             return await this.ExecuteAsync<T>(request);
+        }
+
+        public async Task<bool> CheckAsync(long id)
+        {
+            RestRequest request = this.RequestForHead(pluralEntityName, id);
+            return await this.ExecuteHeadAsync(request);
         }
 
         public async Task<T> AddAsync(T Entity)

--- a/PrestaSharp/Factories/GenericFactory.cs
+++ b/PrestaSharp/Factories/GenericFactory.cs
@@ -28,7 +28,7 @@ namespace Bukimedia.PrestaSharp.Factories
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        public bool Check(long id)
+        public bool CheckIfExists(long id)
         {
             RestRequest request = this.RequestForHead(pluralEntityName, id);
             return this.ExecuteHead(request);
@@ -163,7 +163,12 @@ namespace Bukimedia.PrestaSharp.Factories
             return await this.ExecuteAsync<T>(request);
         }
 
-        public async Task<bool> CheckAsync(long id)
+        /// <summary>
+        /// Checks if the id exists and return true or false
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public async Task<bool> CheckIfExistsAsync(long id)
         {
             RestRequest request = this.RequestForHead(pluralEntityName, id);
             return await this.ExecuteHeadAsync(request);

--- a/PrestaSharp/Factories/ImageFactory.cs
+++ b/PrestaSharp/Factories/ImageFactory.cs
@@ -181,7 +181,7 @@ namespace Bukimedia.PrestaSharp.Factories
         /// </summary>
         /// <param name="ManufacturerId"></param>
         /// <returns></returns>
-        public bool CheckManufacturerImage(long ManufacturerId)
+        public bool CheckIfExistsManufacturerImage(long ManufacturerId)
         {
             return CheckImage("manufacturers", ManufacturerId, null);
         }
@@ -231,7 +231,7 @@ namespace Bukimedia.PrestaSharp.Factories
         /// </summary>
         /// <param name="ManufacturerId"></param>
         /// <returns></returns>
-        public async Task<bool> CheckManufacturerImageAsync(long ManufacturerId)
+        public async Task<bool> CheckIfExistsManufacturerImageAsync(long ManufacturerId)
         {
             return await CheckImageAsync("manufacturers", ManufacturerId, null);
         }
@@ -324,12 +324,14 @@ namespace Bukimedia.PrestaSharp.Factories
         }
 
         /// <summary>
-        /// Checks if the specific product image exists and return true or false
+        /// If Image ID is null checks if product have any images
+        /// else checks if the specific product image exists
+        /// and return true or false
         /// </summary>
         /// <param name="ProductId"></param>
         /// <param name="ImageId"></param>
         /// <returns></returns>
-        public bool CheckProductImage(long ProductId, long ImageId)
+        public bool CheckIfExistsProductImage(long ProductId, long? ImageId)
         {
             return CheckImage("products", ProductId, ImageId);
         }
@@ -381,12 +383,14 @@ namespace Bukimedia.PrestaSharp.Factories
         }
 
         /// <summary>
-        /// Checks if the specific product image exists and return true or false
+        /// If Image ID is null checks if product have any images
+        /// else checks if the specific product image exists
+        /// and return true or false
         /// </summary>
         /// <param name="ProductId"></param>
         /// <param name="ImageId"></param>
         /// <returns></returns>
-        public async Task<bool> CheckProductImageAsync(long ProductId, long ImageId)
+        public async Task<bool> CheckIfExistsProductImageAsync(long ProductId, long ImageId)
         {
             return await CheckImageAsync("products", ProductId, ImageId);
         }
@@ -441,7 +445,7 @@ namespace Bukimedia.PrestaSharp.Factories
         /// </summary>
         /// <param name="CategoryID"></param>
         /// <returns></returns>
-        public bool CheckCategoryImage(long CategoryID)
+        public bool CheckIfExistsCategoryImage(long CategoryID)
         {
             return CheckImage("categories", CategoryID, null);
         }
@@ -498,7 +502,7 @@ namespace Bukimedia.PrestaSharp.Factories
         /// </summary>
         /// <param name="CategoryID"></param>
         /// <returns></returns>
-        public async Task<bool> CheckCategoryImageAsync(long CategoryID)
+        public async Task<bool> CheckIfExistsCategoryImageAsync(long CategoryID)
         {
             return await CheckImageAsync("categories", CategoryID, null);
         }

--- a/PrestaSharp/Factories/ImageFactory.cs
+++ b/PrestaSharp/Factories/ImageFactory.cs
@@ -77,6 +77,12 @@ namespace Bukimedia.PrestaSharp.Factories
             Execute<Entities.image>(request);
         }
 
+        protected bool CheckImage(string Resource, long? ResourceId, long? ImageId)
+        {
+            RestRequest request = RequestForHeadImage(Resource, ResourceId, ImageId);
+            return ExecuteHead(request);
+        }
+
         protected Task<List<Entities.image>> GetAllImagesAsync(string Resource)
         {
             RestRequest request = this.RequestForFilter("images/" + Resource, "full", null, null, null, "images");
@@ -126,6 +132,11 @@ namespace Bukimedia.PrestaSharp.Factories
             return ExecuteAsync<Entities.image>(request);
         }
 
+        protected Task<bool> CheckImageAsync(string Resource, long? ResourceId, long? ImageId)
+        {
+            RestRequest request = RequestForHeadImage(Resource, ResourceId, ImageId);
+            return ExecuteHeadAsync(request);
+        }
         #endregion Protected methods
 
         #region Manufacturer images
@@ -163,6 +174,16 @@ namespace Bukimedia.PrestaSharp.Factories
         public void DeleteManufacturerImage(long ManufacturerId)
         {
             DeleteImage("manufacturers", ManufacturerId, null);
+        }
+
+        /// <summary>
+        /// Checks if manufacturer have image and return true or false
+        /// </summary>
+        /// <param name="ManufacturerId"></param>
+        /// <returns></returns>
+        public bool CheckManufacturerImage(long ManufacturerId)
+        {
+            return CheckImage("manufacturers", ManufacturerId, null);
         }
 
         public byte[] GetManufacturerImage(long ManufacturerId, long ImageId)
@@ -203,6 +224,16 @@ namespace Bukimedia.PrestaSharp.Factories
         public Task DeleteManufacturerImageAsync(long ManufacturerId)
         {
             return DeleteImageAsync("manufacturers", ManufacturerId, null);
+        }
+
+        /// <summary>
+        /// Checks if manufacturer have image and return true or false
+        /// </summary>
+        /// <param name="ManufacturerId"></param>
+        /// <returns></returns>
+        public async Task<bool> CheckManufacturerImageAsync(long ManufacturerId)
+        {
+            return await CheckImageAsync("manufacturers", ManufacturerId, null);
         }
 
         public Task<byte[]> GetManufacturerImageAsync(long ManufacturerId, long ImageId)
@@ -292,6 +323,17 @@ namespace Bukimedia.PrestaSharp.Factories
             DeleteImage("products", ProductId, ImageId);
         }
 
+        /// <summary>
+        /// Checks if the specific product image exists and return true or false
+        /// </summary>
+        /// <param name="ProductId"></param>
+        /// <param name="ImageId"></param>
+        /// <returns></returns>
+        public bool CheckProductImage(long ProductId, long ImageId)
+        {
+            return CheckImage("products", ProductId, ImageId);
+        }
+
         public byte[] GetProductImage(long ProductId, long ImageId)
         {
             RestRequest request = RequestForGet("images/products/" + ProductId, ImageId, "");
@@ -336,6 +378,17 @@ namespace Bukimedia.PrestaSharp.Factories
         public Task DeleteProductImageAsync(long ProductId, long ImageId)
         {
             return DeleteImageAsync("products", ProductId, ImageId);
+        }
+
+        /// <summary>
+        /// Checks if the specific product image exists and return true or false
+        /// </summary>
+        /// <param name="ProductId"></param>
+        /// <param name="ImageId"></param>
+        /// <returns></returns>
+        public async Task<bool> CheckProductImageAsync(long ProductId, long ImageId)
+        {
+            return await CheckImageAsync("products", ProductId, ImageId);
         }
 
         public Task<byte[]> GetProductImageAsync(long ProductId, long ImageId)
@@ -383,6 +436,16 @@ namespace Bukimedia.PrestaSharp.Factories
             DeleteImage("categories", CategoryID, null);
         }
 
+        /// <summary>
+        /// Checks if the category have image and return true or false
+        /// </summary>
+        /// <param name="CategoryID"></param>
+        /// <returns></returns>
+        public bool CheckCategoryImage(long CategoryID)
+        {
+            return CheckImage("categories", CategoryID, null);
+        }
+
         public byte[] GetCategoryImage(long CategoryId, long ImageId)
         {
             RestRequest request = RequestForGet("images/categories/" + CategoryId, ImageId, "");
@@ -428,6 +491,16 @@ namespace Bukimedia.PrestaSharp.Factories
         public Task DeleteCategoryImageAsync(long CategoryID)
         {
             return DeleteImageAsync("categories", CategoryID, null);
+        }
+
+        /// <summary>
+        ///  Checks if the category have image and return true or false
+        /// </summary>
+        /// <param name="CategoryID"></param>
+        /// <returns></returns>
+        public async Task<bool> CheckCategoryImageAsync(long CategoryID)
+        {
+            return await CheckImageAsync("categories", CategoryID, null);
         }
 
         public Task<byte[]> GetCategoryImageAsync(long CategoryId, long ImageId)

--- a/PrestaSharp/Factories/RestSharpFactory.cs
+++ b/PrestaSharp/Factories/RestSharpFactory.cs
@@ -94,6 +94,23 @@ namespace Bukimedia.PrestaSharp.Factories
             return response.Data;
         }
 
+        protected bool ExecuteHead(RestRequest request)
+        {
+            bool r = false;
+            var client = new RestClient
+            {
+                BaseUrl = new Uri(BaseUrl)
+            };
+            AddWsKey(request);
+            AddHandlers(client);
+            var response = client.Execute(request);
+            if(response.StatusCode == HttpStatusCode.OK)
+            {
+                r = true;
+            }
+            return r;
+        }
+
         protected T ExecuteForFilter<T>(RestRequest request) where T : new()
         {
             var client = new RestClient
@@ -139,6 +156,23 @@ namespace Bukimedia.PrestaSharp.Factories
             var response = await client.ExecuteTaskAsync<T>(request);
             CheckResponse(response, request);
             return response.Data;
+        }
+
+        protected async Task<bool> ExecuteHeadAsync(RestRequest request)
+        {
+            bool r = false;
+            var client = new RestClient
+            {
+                BaseUrl = new Uri(BaseUrl)
+            };
+            AddWsKey(request);
+            AddHandlers(client);
+            var response = await client.ExecuteTaskAsync(request);
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                r = true;
+            }
+            return r;
         }
 
         protected async Task<List<long>> ExecuteForGetIdsAsync<T>(RestRequest request, string rootElement) where T : new()
@@ -188,6 +222,16 @@ namespace Bukimedia.PrestaSharp.Factories
                 Method = Method.POST
             };
             AddBody(request, entities);
+            return request;
+        }
+
+        protected RestRequest RequestForHead(string resource, long? id)
+        {
+            var request = new RestRequest
+            {
+                Resource = resource + "/" + id,
+                Method = Method.HEAD
+            };
             return request;
         }
 
@@ -290,6 +334,19 @@ namespace Bukimedia.PrestaSharp.Factories
                 Resource = "/images/" + resource + "/" + resourceId,
                 Method = Method.DELETE,
                 RequestFormat = DataFormat.Xml
+            };
+            if (imageId != null) request.Resource += "/" + imageId;
+            return request;
+        }
+
+        protected RestRequest RequestForHeadImage(string resource, long? resourceId, long? imageId)
+        {
+            if (resourceId == null) throw new ApplicationException("Id is required to check if exists something.");
+
+            var request = new RestRequest
+            {
+                Resource = "/images/" + resource + "/" + resourceId,
+                Method = Method.HEAD,
             };
             if (imageId != null) request.Resource += "/" + imageId;
             return request;


### PR DESCRIPTION
You can check if ID exists for entities and for images via head request.

ex.
blExists = manufacturerFactory.CheckIfExists(lngManufacturerID);
blExists = productFactory.CheckIfExists(lngProductID);
blExists = imageFactory.CheckIfExistsCategoryImage(lngCategoryID);
blExists = imageFactory.CheckIfExistsManufacturerImage(lngManufacturerID);
blExists = imageFactory.CheckIfExistsProductImage(lngProductID, lngImageID);
blExists = imageFactory.CheckIfExistsProductImage(lngProductID, null);


