### PR TITLE
Support for Orders Product Customization added

### DIFF
--- a/PrestaSharp/Entities/AuxEntities/AssociationsCustomization.cs
+++ b/PrestaSharp/Entities/AuxEntities/AssociationsCustomization.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities.AuxEntities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities/AuxEntities")]
+    public class AssociationsCustomization : PrestaShopEntity
+    {
+        public List<customized_data_text_field> customized_data_text_fields { get; set; }
+
+        public AssociationsCustomization()
+        {
+            this.customized_data_text_fields = new List<customized_data_text_field>();
+        }
+
+    }
+}

--- a/PrestaSharp/Entities/customization.cs
+++ b/PrestaSharp/Entities/customization.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities")]
+    public class customization : PrestaShopEntity, IPrestaShopFactoryEntity
+    {
+        public long? id { get; set; }
+        public long? id_address_delivery { get; set; }
+        public long? id_cart { get; set; }
+        public long? id_product { get; set; }
+        public long? id_product_attribute { get; set; }
+        public long? quantity { get; set; }
+        public long? quantity_refunded { get; set; }
+        /// <summary>
+        /// It´s a logical bool.
+        /// </summary
+        public int in_cart { get; set; }
+        public AuxEntities.AssociationsCustomization associations { get; set; }
+
+        public customization()
+        {
+            this.associations = new AuxEntities.AssociationsCustomization();
+        }
+    }
+}

--- a/PrestaSharp/Entities/customized_data_text_field.cs
+++ b/PrestaSharp/Entities/customized_data_text_field.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace Bukimedia.PrestaSharp.Entities
+{
+    [XmlType(Namespace = "Bukimedia/PrestaSharp/Entities")]
+    public class customized_data_text_field : PrestaShopEntity
+    {
+        public long? id_customization_field { get; set; }
+        public string value { get; set; }
+
+        public customized_data_text_field()
+        {
+        }
+    }
+}

--- a/PrestaSharp/Entities/order_detail.cs
+++ b/PrestaSharp/Entities/order_detail.cs
@@ -30,6 +30,7 @@ namespace Bukimedia.PrestaSharp.Entities
         public long? id_order_invoice { get; set; }
         public long? id_warehouse { get; set; }
         public long? id_shop { get; set; }
+        public long? id_customization { get; set; }
         public string product_name { get; set; }
         public int product_quantity { get; set; }
         public int product_quantity_in_stock { get; set; }
@@ -42,6 +43,7 @@ namespace Bukimedia.PrestaSharp.Entities
         public decimal reduction_amount_tax_excl { get; set; }
         public decimal product_quantity_discount { get; set; }
         public string product_ean13 { get; set; }
+        public string product_isbn { get; set; }
         public string product_upc { get; set; }
         public string product_reference { get; set; }
         public string product_supplier_reference { get; set; }
@@ -60,6 +62,8 @@ namespace Bukimedia.PrestaSharp.Entities
         public decimal purchase_supplier_price { get; set; }
         public decimal original_product_price { get; set; }
         public decimal original_wholesale_price { get; set; }
+        public decimal total_refunded_tax_excl { get; set; }
+        public decimal total_refunded_tax_incl { get; set; }
 
         public order_detail()
         {

--- a/PrestaSharp/Factories/CustomizationFactory.cs
+++ b/PrestaSharp/Factories/CustomizationFactory.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Bukimedia.PrestaSharp.Entities;
+
+namespace Bukimedia.PrestaSharp.Factories
+{
+    public class CustomizationFactory : GenericFactory<customization>
+    {
+        protected override string singularEntityName { get { return "customization"; } }
+        protected override string pluralEntityName { get { return "customizations"; } }
+
+        public CustomizationFactory(string BaseUrl, string Account, string SecretKey)
+            : base(BaseUrl, Account, SecretKey)
+        {
+        }
+    }
+}


### PR DESCRIPTION
After you get the order details you can loop to get customization if exists like this

```
foreach (Bukimedia.PrestaSharp.Entities.order_detail myOrderDetail in myOrderDetails)
{
    if (myOrderDetail.id_customization != null)
    {
        long lngCustomID = myOrderDetail.id_customization.Value;
        if (lngCustomID > 0)
        {
            try
            {
                Bukimedia.PrestaSharp.Entities.customization myCustomization = LibLocal.customizationFactory.Get(lngCustomID);
                foreach (Bukimedia.PrestaSharp.Entities.customized_data_text_field myCustomizedDataTextField in myCustomization.associations.customized_data_text_fields)
                {
                    Console.WriteLine(myCustomizedDataTextField.value);
                }
            }
            catch (Exception ex)
            {
                LibLocal.WriteToLog("Exception: OrderCustomization: " + ex.Message);
            }
        }
    }
}
```